### PR TITLE
Don't iterate js map with "var … in"

### DIFF
--- a/src/JS/Map/Primitive/Internal.js
+++ b/src/JS/Map/Primitive/Internal.js
@@ -13,7 +13,7 @@ export const _fmapMap = (m0, f) => {
 
 export function _mapWithKey(m0, f) {
   const m = new Map()
-  for (const [k, v] of m0) 
+  for (const [k, v] of m0)
     m.set(k, f(k)(v))
   return m
 }
@@ -40,8 +40,8 @@ export const _foldSCMap = (m, z, f, fromMaybe) => {
 }
 
 export const _all = f => m => {
-  for (var k in m) {
-    if (!f(k)(m.get(k))) return false
+  for (let [k, v] of m) {
+    if (!f(k)(v)) return false
   }
   return true
 }


### PR DESCRIPTION
JavaScript as it often happens decided to implement different behavior of syntax compared to other langs. Instead of iterating the key/val as one'd expect it iterates enumerable properties of a Map.

Fix this by using `let [k, v] of` syntax instead.

Fixes: https://github.com/gbagan/purescript-js-maps/issues/4