### PR TITLE
Don't apply `show` while "encoding" a string

### DIFF
--- a/src/JS/Map/EncodeKey.purs
+++ b/src/JS/Map/EncodeKey.purs
@@ -14,7 +14,7 @@ instance EncodeKey Int where
   encodeKey = show
 
 instance EncodeKey String where
-  encodeKey = show
+  encodeKey s = s
 
 instance (EncodeKey a, EncodeKey b) => EncodeKey (Tuple a b) where
   encodeKey (Tuple a b) = "(" <> encodeKey a <> "," <> encodeKey b <> ")"


### PR DESCRIPTION
There's no need to "show" a string, because it is already "encoded". If anything, applying `show` to it in such context only introduces an unnecessary indirection point and potential bugs while interacting with JS.

Fixes: https://github.com/gbagan/purescript-js-maps/issues/7